### PR TITLE
Remove badge link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 A Jekyll plugin to add metadata tags for search engines and social networks to better index and display your site's content.
 
-[![Build Status](https://travis-ci.com/emmasax4/jekyll-seo-tag.svg?branch=main)](https://travis-ci.com/emmasax4/jekyll-seo-tag) [![Gem Version](https://badge.fury.io/rb/jekyll-seo-tag.svg)](https://badge.fury.io/rb/jekyll-seo-tag)
+[![Build Status](https://travis-ci.com/emmasax4/jekyll-seo-tag.svg?branch=main)](https://travis-ci.com/emmasax4/jekyll-seo-tag)
 
 ## What it does
 


### PR DESCRIPTION
This fork of this project does not use the tagged versions, but rather just the `main` branch. So, it's not necessary to have the tagged version showing.