### PR TITLE
Test out new ubuntu version

### DIFF
--- a/.github/workflows/third-party-profiling.yml
+++ b/.github/workflows/third-party-profiling.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-profile:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-20.04'
     steps:
     - name: Checkout Jekyll SEO Tag
       uses: actions/checkout@v2


### PR DESCRIPTION
I wanted to make sure that the newest version of GitHub Actions ubuntu OS works on this workflow. Documentation [here](https://github.com/actions/virtual-environments/issues/1816) and [here](https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04/).

Now that we know that this works, we can close this PR and just wait for that version to become the newest version (called with just `ubuntu-latest`).