### PR TITLE
Sort JSON LD drop

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Minor Enhancements
+
+  * Allow to set type for author (#427)
+
 ## 2.7.1 / 2020-10-18
 
 ### Development Fixes

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -128,7 +128,6 @@ module Jekyll
 
       # A drop representing the JSON-LD output
       def json_ld
-        # puts JSONLDDrop.new(self).to_json
         @json_ld ||= JSONLDDrop.new(self)
       end
 

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -128,6 +128,7 @@ module Jekyll
 
       # A drop representing the JSON-LD output
       def json_ld
+        # puts JSONLDDrop.new(self).to_json
         @json_ld ||= JSONLDDrop.new(self)
       end
 

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -80,7 +80,12 @@ module Jekyll
       private :main_entity
 
       def to_json
-        to_h.reject { |_k, v| v.nil? }.to_json
+        sort_order = [
+          'headline', 'name', 'url', 'mainEntityOfPage', 'dateModified', 'datePublished',
+          'author', 'publisher', 'description', 'sameAs', 'image', '@type', '@context'
+        ]
+        hash = (sort_order & to_h.keys).map { |k| [k, to_h[k]] }.to_h
+        hash.reject { |_k, v| v.nil? }.to_json
       end
 
       private

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -21,7 +21,8 @@ module Jekyll
       private :logo
 
       VALID_ENTITY_TYPES = %w(BlogPosting CreativeWork).freeze
-      private_constant :VALID_ENTITY_TYPES
+      VALID_AUTHOR_TYPES = %w(Organization Person).freeze
+      private_constant :VALID_ENTITY_TYPES, :VALID_AUTHOR_TYPES
 
       # page_drop should be an instance of Jekyll::SeoTag::Drop
       def initialize(page_drop)
@@ -38,8 +39,11 @@ module Jekyll
       def author
         return unless page_drop.author["name"]
 
+        author_type = page_drop.author["type"]
+        return if author_type && !VALID_AUTHOR_TYPES.include?(author_type)
+
         {
-          "@type" => "Person",
+          "@type" => author_type || "Person",
           "name"  => page_drop.author["name"],
         }
       end

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
         end
       end
     end
+
+    context "when type Organization" do
+      let(:author) { { "name" => "organization", "type" => "Organization" } }
+
+      it "returns the author with type" do
+        expect(subject).to have_key("author")
+        expect(subject["author"]).to be_a(Hash)
+        expect(subject["author"]).to have_key("@type")
+        expect(subject["author"]["@type"]).to eql("Organization")
+        expect(subject["author"]).to have_key("name")
+        expect(subject["author"]["name"]).to be_a(String)
+        expect(subject["author"]["name"]).to eql("organization")
+      end
+    end
+
+    context "when invalid type" do
+      let(:author) { { "name" => "organization", "type" => "Invalid" } }
+
+      it "returns the author with type" do
+        expect(subject).to have_key("author")
+        expect(subject["author"]).to be nil
+      end
+    end
   end
 
   context "image" do

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -160,4 +160,19 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
       expect(subject.to_json).to_not match(%r!:null!)
     end
   end
+
+  context "sorting the final json value" do
+    it "accurately sorts the final json value based on the sort precedence set" do
+      any_char = %r{[\/a-zA-Z\d\s:-]+}
+      match_one = %r{"headline":"#{any_char}","name":"#{any_char}","url":"}
+      match_two = %r{"dateModified":"#{any_char}","datePublished":"#{any_char}","author":}
+      match_three = %r{"description":"#{any_char}","sameAs":}
+      match_four = %r{"image":"#{any_char}","@type":"#{any_char}","@context":"#{any_char}"}
+      expect(subject.to_json).to start_with('{"headline')
+      expect(subject.to_json).to match(match_one)
+      expect(subject.to_json).to match(match_two)
+      expect(subject.to_json).to match(match_three)
+      expect(subject.to_json).to end_with('"@type":"BlogPosting","@context":"https://schema.org"}')
+    end
+  end
 end


### PR DESCRIPTION
One thing I've noticed in my website, which has been very irritating, is that the sorting order of the ld JSON changes frequently between builds. For an example, see [this commit](https://github.com/emmasax4/emmasax4.com/commit/6308fb340c27d8d9fe83ab4d011aadda10fb781a). It happens on all of my projects, and takes what may be a very small commit, and makes it massive as it changes every single `index.html` file.

So, I developed what seems to be an accurate sorting order for myself, and now would like to sort those values before writing them each time.