### PR TITLE
Be able to create a generic common title or a special one

### DIFF
--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -33,7 +33,7 @@ module Jekyll
         @display_title = (@text !~ %r!title=false!i)
       end
 
-      def site_title_prioritization?
+      def site_title_prioritized?
         site["seo_title_prioritization"] == "site"
       end
 
@@ -74,14 +74,14 @@ module Jekyll
 
       # Page title with site title or description appended
       def title
-        @title ||= site_title_prioritization? ? determine_site_priority_title : determine_generic_title
+        @title ||= site_title_prioritized? ? site_title_prioritized_title : generic_title
 
         return @title + page_number if page_number
 
         @title
       end
 
-      def determine_generic_title
+      def generic_title
         if site_title && page_title != site_title
           page_title + TITLE_SEPARATOR + site_title
         elsif site_description && site_title
@@ -91,18 +91,18 @@ module Jekyll
         end
       end
 
-      def determine_site_priority_title
+      def site_title_prioritized_title
         if site_title && (page_title == "Home" || page["title"].nil?)
           site_title
         elsif site_title
-          determine_title || site_title
+          determine_detailed_title || site_title
         else
           page_title
         end
       end
 
       # rubocop:disable Metrics/AbcSize
-      def determine_title
+      def determine_detailed_title
         if page_pagination_title
           site_title + TITLE_SEPARATOR + page_pagination_title
         elsif page_subtitle_title

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -33,6 +33,10 @@ module Jekyll
         @display_title = (@text !~ %r!title=false!i)
       end
 
+      def emmasax4_site?
+        site_title == "Emma Sax"
+      end
+
       def site_title
         @site_title ||= format_string(site["title"] || site["name"])
       end
@@ -68,24 +72,34 @@ module Jekyll
         site_tagline || site_description
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
       # Page title with site title or description appended
       def title
-        @title ||= begin
-          if site_title && (page_title == "Home" || page["title"].nil?)
-            site_title
-          elsif site_title
-            determine_title || site_title
-          else
-            page_title
-          end
-        end
+        @title ||= emmasax4_site? ? determine_emmasax4_title : determine_generic_title
 
         return @title + page_number if page_number
 
         @title
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def determine_generic_title
+        if site_title && page_title != site_title
+          page_title + TITLE_SEPARATOR + site_title
+        elsif site_description && site_title
+          site_title + TITLE_SEPARATOR + site_tagline_or_description
+        else
+          page_title || site_title
+        end
+      end
+
+      def determine_emmasax4_title
+        if site_title && (page_title == "Home" || page["title"].nil?)
+          site_title
+        elsif site_title
+          determine_title || site_title
+        else
+          page_title
+        end
+      end
 
       # rubocop:disable Metrics/AbcSize
       def determine_title

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -33,8 +33,8 @@ module Jekyll
         @display_title = (@text !~ %r!title=false!i)
       end
 
-      def emmasax4_site?
-        site_title == "Emma Sax"
+      def site_title_prioritization?
+        site["seo_title_prioritization"] == "site"
       end
 
       def site_title
@@ -74,7 +74,7 @@ module Jekyll
 
       # Page title with site title or description appended
       def title
-        @title ||= emmasax4_site? ? determine_emmasax4_title : determine_generic_title
+        @title ||= site_title_prioritization? ? determine_site_priority_title : determine_generic_title
 
         return @title + page_number if page_number
 
@@ -91,7 +91,7 @@ module Jekyll
         end
       end
 
-      def determine_emmasax4_title
+      def determine_site_priority_title
         if site_title && (page_title == "Home" || page["title"].nil?)
           site_title
         elsif site_title

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,7 +5,7 @@
 
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
-{% if seo_tag.site_prioritization? %}
+{% if seo_tag.site_title_prioritized? %}
   {% if seo_tag.title? %}
     <meta property="og:title" content="{{ seo_tag.title }}" />
   {% endif %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,8 +5,14 @@
 
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
-{% if seo_tag.title? %}
-  <meta property="og:title" content="{{ seo_tag.title }}" />
+{% if seo_tag.emmasax4_site? %}
+  {% if seo_tag.title? %}
+    <meta property="og:title" content="{{ seo_tag.title }}" />
+  {% endif %}
+{% else %}
+  {% if seo_tag.page_title %}
+    <meta property="og:title" content="{{ seo_tag.page_title }}" />
+  {% endif %}
 {% endif %}
 
 {% if seo_tag.author.name %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,7 +5,7 @@
 
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
-{% if seo_tag.emmasax4_site? %}
+{% if seo_tag.site_prioritization? %}
   {% if seo_tag.title? %}
     <meta property="og:title" content="{{ seo_tag.title }}" />
   {% endif %}

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
       context "with a page and site title" do
         context "when site title prioritized" do
           it "builds the title" do
-            allow(subject).to receive(:site_title_prioritization?).and_return(true)
+            allow(subject).to receive(:site_title_prioritized?).and_return(true)
             expect(subject.title).to eql("site title | page title")
           end
         end
@@ -277,10 +277,10 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
     end
 
-    context "determine_title" do
+    context "determine_detailed_title" do
       context "with a page and site title" do
         it "builds the title" do
-          expect(subject.determine_title).to eql("site title | page title")
+          expect(subject.determine_detailed_title).to eql("site title | page title")
         end
       end
 
@@ -291,7 +291,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
 
         it "builds the title" do
-          expect(subject.determine_title).to eql("site title | site description")
+          expect(subject.determine_detailed_title).to eql("site title | site description")
         end
       end
 
@@ -302,7 +302,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
 
         it "builds the title" do
-          expect(subject.determine_title).to eql("site title | site tagline")
+          expect(subject.determine_detailed_title).to eql("site title | site tagline")
         end
       end
 
@@ -313,7 +313,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         let(:page) { make_page(page_meta) }
 
         it "builds the title" do
-          expect(subject.determine_title).to eql("site title | pagination title")
+          expect(subject.determine_detailed_title).to eql("site title | pagination title")
         end
       end
 
@@ -325,7 +325,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         let(:title_separator) { "—" }
 
         it "builds the title" do
-          expect(subject.determine_title).to eql("site title | site title #{title_separator} subtitle")
+          expect(subject.determine_detailed_title).to eql("site title | site title #{title_separator} subtitle")
         end
       end
     end

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -132,14 +132,14 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
     context "title" do
       context "with a page and site title" do
-        context "when emmasax4 site" do
+        context "when site title prioritized" do
           it "builds the title" do
-            allow(subject).to receive(:emmasax4_site?).and_return(true)
+            allow(subject).to receive(:site_title_prioritization?).and_return(true)
             expect(subject.title).to eql("site title | page title")
           end
         end
 
-        context "when generic site" do
+        context "when page title prioritized" do
           it "builds the title" do
             expect(subject.title).to eql("page title | site title")
           end
@@ -147,18 +147,18 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with a site description but no page title" do
-        context "when emmasax4 site" do
+        context "when site title prioritized" do
           let(:page)  { make_page }
           let(:config) do
-            { "title" => "Emma Sax", "description" => "site description" }
+            { "title" => "Site Title", "description" => "site description", "seo_title_prioritization" => "site" }
           end
 
           it "builds the title" do
-            expect(subject.title).to eql("Emma Sax")
+            expect(subject.title).to eql("Site Title")
           end
         end
 
-        context "when generic site" do
+        context "when page title prioritized" do
           let(:page)  { make_page }
           let(:config) do
             { "title" => "site title", "description" => "site description" }
@@ -171,18 +171,18 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with a site tagline but no page title" do
-        context "when emmasax4 site" do
+        context "when site title prioritized" do
           let(:page)  { make_page }
           let(:config) do
-            { "title" => "Emma Sax", "description" => "site description", "tagline" => "site tagline" }
+            { "title" => "Site Title", "description" => "site description", "tagline" => "site tagline", "seo_title_prioritization" => "site" }
           end
 
           it "builds the title" do
-            expect(subject.title).to eql("Emma Sax")
+            expect(subject.title).to eql("Site Title")
           end
         end
 
-        context "when generic site" do
+        context "when page title prioritized" do
           let(:page)  { make_page }
           let(:config) do
             { "title" => "site title", "description" => "site description", "tagline" => "site tagline" }
@@ -245,19 +245,19 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "when the page title is Home" do
-        context "when emmasax4 site" do
+        context "when site title prioritized" do
           let(:page_meta) { { "title" => "Home" } }
           let(:page)      { make_page(page_meta) }
           let(:config) do
-            { "title" => "Emma Sax", "description" => "site description", "tagline" => "site tagline" }
+            { "title" => "Site Title", "description" => "site description", "tagline" => "site tagline", "seo_title_prioritization" => "site" }
           end
 
           it "should return only the site title" do
-            expect(subject.title).to eql("Emma Sax")
+            expect(subject.title).to eql("Site Title")
           end
         end
 
-        context "when generic site" do
+        context "when page title prioritized" do
           let(:page_meta) { { "title" => "Home" } }
           let(:page)      { make_page(page_meta) }
 

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -132,30 +132,65 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
     context "title" do
       context "with a page and site title" do
-        it "builds the title" do
-          expect(subject.title).to eql("site title | page title")
+        context "when emmasax4 site" do
+          it "builds the title" do
+            allow(subject).to receive(:emmasax4_site?).and_return(true)
+            expect(subject.title).to eql("site title | page title")
+          end
+        end
+
+        context "when generic site" do
+          it "builds the title" do
+            expect(subject.title).to eql("page title | site title")
+          end
         end
       end
 
       context "with a site description but no page title" do
-        let(:page)  { make_page }
-        let(:config) do
-          { "title" => "site title", "description" => "site description" }
+        context "when emmasax4 site" do
+          let(:page)  { make_page }
+          let(:config) do
+            { "title" => "Emma Sax", "description" => "site description" }
+          end
+
+          it "builds the title" do
+            expect(subject.title).to eql("Emma Sax")
+          end
         end
 
-        it "builds the title" do
-          expect(subject.title).to eql("site title")
+        context "when generic site" do
+          let(:page)  { make_page }
+          let(:config) do
+            { "title" => "site title", "description" => "site description" }
+          end
+
+          it "builds the title" do
+            expect(subject.title).to eql("site title | site description")
+          end
         end
       end
 
       context "with a site tagline but no page title" do
-        let(:page)  { make_page }
-        let(:config) do
-          { "title" => "site title", "description" => "site description", "tagline" => "site tagline" }
+        context "when emmasax4 site" do
+          let(:page)  { make_page }
+          let(:config) do
+            { "title" => "Emma Sax", "description" => "site description", "tagline" => "site tagline" }
+          end
+
+          it "builds the title" do
+            expect(subject.title).to eql("Emma Sax")
+          end
         end
 
-        it "builds the title" do
-          expect(subject.title).to eql("site title")
+        context "when generic site" do
+          let(:page)  { make_page }
+          let(:config) do
+            { "title" => "site title", "description" => "site description", "tagline" => "site tagline" }
+          end
+
+          it "builds the title" do
+            expect(subject.title).to eql("site title | site tagline")
+          end
         end
       end
 
@@ -210,11 +245,25 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "when the page title is Home" do
-        let(:page_meta) { { "title" => "Home" } }
-        let(:page)      { make_page(page_meta) }
+        context "when emmasax4 site" do
+          let(:page_meta) { { "title" => "Home" } }
+          let(:page)      { make_page(page_meta) }
+          let(:config) do
+            { "title" => "Emma Sax", "description" => "site description", "tagline" => "site tagline" }
+          end
 
-        it "should return only the site title" do
-          expect(subject.title).to eql("site title")
+          it "should return only the site title" do
+            expect(subject.title).to eql("Emma Sax")
+          end
+        end
+
+        context "when generic site" do
+          let(:page_meta) { { "title" => "Home" } }
+          let(:page)      { make_page(page_meta) }
+
+          it "should return only the site title" do
+            expect(subject.title).to eql("Home | site title")
+          end
         end
       end
 

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -49,18 +49,38 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.name" do
-      let(:site) { make_site("name" => "Site Name") }
+      context "when emmasax4 site" do
+        let(:site) { make_site("name" => "Emma Sax") }
 
-      it "builds the title with a page title and site name" do
-        expect(output).to match(%r!<title>Site Name \| foo</title>!)
+        it "builds the title with a page title and site name" do
+          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+        end
+      end
+
+      context "when generic site" do
+        let(:site) { make_site("name" => "Site Name") }
+
+        it "builds the title with a page title and site name" do
+          expect(output).to match(%r!<title>foo \| Site Name</title>!)
+        end
       end
     end
 
     context "with site.title" do
-      let(:site) { make_site("title" => "bar") }
+      context "when emmasax4 site" do
+        let(:site) { make_site("title" => "Emma Sax") }
 
-      it "builds the title with a page title and site title" do
-        expect(output).to match(%r!<title>bar \| foo</title>!)
+        it "builds the title with a page title and site title" do
+          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+        end
+      end
+
+      context "when generic site" do
+        let(:site) { make_site("title" => "bar") }
+
+        it "builds the title with a page title and site title" do
+          expect(output).to match(%r!<title>foo \| bar</title>!)
+        end
       end
     end
 
@@ -73,18 +93,24 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.title and site.description" do
-      let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+      context "when emmasax4 site" do
+        let(:site) { make_site("title" => "Emma Sax", "description" => "Site Description") }
 
-      it "builds the title with a page title and site title" do
-        expect(output).to match(%r!<title>Site Title \| foo</title>!)
+        it "builds the title with a page title and site title" do
+          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+        end
+      end
+
+      context "when generic site" do
+        let(:site) { make_site("title" => "foo", "description" => "Site Description") }
+
+        it "builds the title with a page title and site description" do
+          expect(output).to match(%r!<title>foo \| Site Description</title>!)
+        end
       end
 
       it "does not build the title with the site description" do
         expect(output).not_to match(%r!<title>foo \| Site Description</title>!)
-      end
-
-      it "builds the title with a page title and site title" do
-        expect(output).to match(%r!<title>Site Title \| foo</title>!)
       end
 
       it "does not build the title with the site description" do
@@ -102,45 +128,71 @@ RSpec.describe Jekyll::SeoTag do
   end
 
   context "with site.title and page.pagination.title" do
-    let(:site) { make_site("title" => "Site title") }
-    let(:page_meta) do
-      { "title" => "site title", "pagination" => { "title" => "pagination title" } }
-    end
-    let(:page) { make_page(page_meta) }
+    context "when emmasax4 site" do
+      let(:site) { make_site("title" => "Emma Sax") }
+      let(:page_meta) do
+        { "title" => "site title", "pagination" => { "title" => "pagination title" } }
+      end
+      let(:page) { make_page(page_meta) }
 
-    it "should build the title" do
-      expect(output).to match(%r!<title>Site title | pagination title</title>!)
+      it "should build the title" do
+        expect(output).to match(%r!<title>Emma Sax | pagination title</title>!)
+      end
     end
   end
 
   context "with site.title, page.title, and page.subtitle" do
-    let(:site)      { make_site("title" => "Site title") }
-    let(:title)     { "Test Title" }
-    let(:subtitle)  { "Subtitle" }
-    let(:page_meta) { { "title" => title, "subtitle" => subtitle } }
-    let(:page)      { make_page(page_meta) }
+    context "when emmasax4 site" do
+      let(:site)      { make_site("title" => "Emma Sax") }
+      let(:title)     { "Test Title" }
+      let(:subtitle)  { "Subtitle" }
+      let(:page_meta) { { "title" => title, "subtitle" => subtitle } }
+      let(:page)      { make_page(page_meta) }
 
-    it "should build the title" do
-      expect(output).to match(%r!<title>Site title | title — subtitle</title>!)
+      it "should build the title" do
+        expect(output).to match(%r!<title>Emma Sax | title — subtitle</title>!)
+      end
+    end
+
+    context "when generic site" do
+      let(:site)      { make_site("title" => "Site Title") }
+      let(:title)     { "Test Title" }
+      let(:subtitle)  { "Subtitle" }
+      let(:page_meta) { { "title" => title, "subtitle" => subtitle } }
+      let(:page)      { make_page(page_meta) }
+
+      it "should build the title" do
+        expect(output).to match(%r!<title>Test Title | Site Title</title>!)
+      end
     end
   end
 
-  context "with site.title and page.title == Home" do
-    let(:site)      { make_site("title" => "Site title") }
+  context "with site.title and page.title == Home and emmasax4 site" do
+    let(:site)      { make_site("title" => "Emma Sax") }
     let(:title)     { "Home" }
     let(:page_meta) { { "title" => title } }
     let(:page)      { make_page(page_meta) }
 
     it "should build the title" do
-      expect(output).to match(%r!<title>Site title</title>!)
+      expect(output).to match(%r!<title>Emma Sax</title>!)
     end
   end
 
   context "with site.title and site.description" do
-    let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+    context "when emmasax4 site" do
+      let(:site) { make_site("title" => "Emma Sax", "description" => "Site Description") }
 
-    it "builds the title with site title and description" do
-      expect(output).to match(%r!<title>Site Title</title>!)
+      it "builds the title with site title and description" do
+        expect(output).to match(%r!<title>Emma Sax</title>!)
+      end
+    end
+
+    context "when generic site" do
+      let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
+
+      it "builds the title with site title and description" do
+        expect(output).to match(%r!<title>Site Title \| Site Description</title>!)
+      end
     end
   end
 

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -49,15 +49,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.name" do
-      context "when emmasax4 site" do
-        let(:site) { make_site("name" => "Emma Sax") }
+      context "when site title prioritized" do
+        let(:site) { make_site("name" => "Site Title", "seo_title_prioritization" => "site") }
 
         it "builds the title with a page title and site name" do
-          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+          expect(output).to match(%r!<title>Site Title \| foo</title>!)
         end
       end
 
-      context "when generic site" do
+      context "when page title prioritized" do
         let(:site) { make_site("name" => "Site Name") }
 
         it "builds the title with a page title and site name" do
@@ -67,15 +67,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.title" do
-      context "when emmasax4 site" do
-        let(:site) { make_site("title" => "Emma Sax") }
+      context "when site title prioritized" do
+        let(:site) { make_site("title" => "Site Title", "seo_title_prioritization" => "site" ) }
 
         it "builds the title with a page title and site title" do
-          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+          expect(output).to match(%r!<title>Site Title \| foo</title>!)
         end
       end
 
-      context "when generic site" do
+      context "when page title prioritized" do
         let(:site) { make_site("title" => "bar") }
 
         it "builds the title with a page title and site title" do
@@ -93,15 +93,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.title and site.description" do
-      context "when emmasax4 site" do
-        let(:site) { make_site("title" => "Emma Sax", "description" => "Site Description") }
+      context "when site title prioritized" do
+        let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_title_prioritization" => "site") }
 
         it "builds the title with a page title and site title" do
-          expect(output).to match(%r!<title>Emma Sax \| foo</title>!)
+          expect(output).to match(%r!<title>Site Title \| foo</title>!)
         end
       end
 
-      context "when generic site" do
+      context "when page title prioritized" do
         let(:site) { make_site("title" => "foo", "description" => "Site Description") }
 
         it "builds the title with a page title and site description" do
@@ -128,33 +128,33 @@ RSpec.describe Jekyll::SeoTag do
   end
 
   context "with site.title and page.pagination.title" do
-    context "when emmasax4 site" do
-      let(:site) { make_site("title" => "Emma Sax") }
+    context "when site title prioritized" do
+      let(:site) { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
       let(:page_meta) do
         { "title" => "site title", "pagination" => { "title" => "pagination title" } }
       end
       let(:page) { make_page(page_meta) }
 
       it "should build the title" do
-        expect(output).to match(%r!<title>Emma Sax | pagination title</title>!)
+        expect(output).to match(%r!<title>Site Title | pagination title</title>!)
       end
     end
   end
 
   context "with site.title, page.title, and page.subtitle" do
-    context "when emmasax4 site" do
-      let(:site)      { make_site("title" => "Emma Sax") }
+    context "when site title prioritized" do
+      let(:site)      { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
       let(:title)     { "Test Title" }
       let(:subtitle)  { "Subtitle" }
       let(:page_meta) { { "title" => title, "subtitle" => subtitle } }
       let(:page)      { make_page(page_meta) }
 
       it "should build the title" do
-        expect(output).to match(%r!<title>Emma Sax | title — subtitle</title>!)
+        expect(output).to match(%r!<title>Site Title | title — subtitle</title>!)
       end
     end
 
-    context "when generic site" do
+    context "when page title prioritized" do
       let(:site)      { make_site("title" => "Site Title") }
       let(:title)     { "Test Title" }
       let(:subtitle)  { "Subtitle" }
@@ -168,26 +168,26 @@ RSpec.describe Jekyll::SeoTag do
   end
 
   context "with site.title and page.title == Home and emmasax4 site" do
-    let(:site)      { make_site("title" => "Emma Sax") }
+    let(:site)      { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
     let(:title)     { "Home" }
     let(:page_meta) { { "title" => title } }
     let(:page)      { make_page(page_meta) }
 
     it "should build the title" do
-      expect(output).to match(%r!<title>Emma Sax</title>!)
+      expect(output).to match(%r!<title>Site Title</title>!)
     end
   end
 
   context "with site.title and site.description" do
-    context "when emmasax4 site" do
-      let(:site) { make_site("title" => "Emma Sax", "description" => "Site Description") }
+    context "when site title prioritized" do
+      let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_title_prioritization" => "site") }
 
       it "builds the title with site title and description" do
-        expect(output).to match(%r!<title>Emma Sax</title>!)
+        expect(output).to match(%r!<title>Site Title</title>!)
       end
     end
 
-    context "when generic site" do
+    context "when page title prioritized" do
       let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
 
       it "builds the title with site title and description" do


### PR DESCRIPTION
Change the gem to be able to determine a generic title (AKA the title that the normal gem uses) or the title for what is currently just my specific website. I can indicate whether I want the title to put the site title first or the page title first:
```
Site Title | Page Title
```
versus
```
Page Title | Site Title
```
by specifying this in the `_config.yml`:
```yml
seo_title_prioritization: site
```