### PR TITLE
Try removing the commonmarker dependency

### DIFF
--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", ">= 3.8", "< 5.0"
-  spec.add_dependency "commonmarker", "< 0.22"
 
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "guard-rspec", "~> 4.7"


### PR DESCRIPTION
Try seeing if we can remove the dependency rules on commonmarker gem now that version 0.23.1 has been released.