### PR TITLE
Update gemspec

### DIFF
--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64", "~> 0.2"
+  spec.add_dependency "csv", "~> 3.2"
   spec.add_dependency "jekyll", ">= 3.8", "< 5.0"
   spec.add_dependency "rake", "~> 13.0"
 


### PR DESCRIPTION
Without these gems, I get this warning:
```
/Users/emmasax/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/jekyll-4.3.3/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of jekyll-4.3.3 to add csv into its gemspec.
/Users/emmasax/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/transform.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of safe_yaml-1.0.5 to add base64 into its gemspec.
```